### PR TITLE
Leader demotion bug fix

### DIFF
--- a/lib/election.js
+++ b/lib/election.js
@@ -197,7 +197,7 @@ module.exports.Configure = function(praetor) {
     praetor.legiond.on('praetor.demotion', () => {
         const attributes = praetor.legiond.get_attributes();
 
-        if(attributes.praetor.leader_eligible) {
+        if(attributes.praetor.leader_eligible && !praetor.get_controlling_leader()) {
             praetor.actions.elect();
         }
     });


### PR DESCRIPTION
* Only trigger a new election on a demotion if there is no existing
controlling leader. This would happen in the case where we temporarily
have two controlling leaders and one leader demotes the other leader.

@normanjoyner 